### PR TITLE
Preparation for supporting VAST ad for video content.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 .idea/
 *.hmap
 *.xccheckout
+*xcuserdata*
 
 #CocoaPods
 Pods

--- a/Classes/IDMPhoto.h
+++ b/Classes/IDMPhoto.h
@@ -10,6 +10,13 @@
 #import "IDMPhotoProtocol.h"
 #import <SDWebImage/SDWebImageManager.h>
 
+typedef NS_ENUM(NSUInteger, IDMVASTAdPlayType) {
+    kIDMVASTAdPlayTypePreRoll                   = 0 ,
+    kIDMVASTAdPlayTypeMidRoll,
+    kIDMVASTAdPlayTypePostRoll,
+    kIDMVASTAdPlayTypeDefault                   = kIDMVASTAdPlayTypePostRoll
+};
+
 // This class models a photo/image and it's caption
 // If you want to handle photos, caching, decompression
 // yourself then you can simply ensure your custom data model
@@ -26,6 +33,8 @@ typedef void (^IDMProgressUpdateBlock)(CGFloat progress);
 @property (nonatomic, strong) NSURL *videoURL;
 @property (nonatomic, strong) UIImage *videoThumbnail;
 @property (nonatomic, strong) NSURL *videoThumbnailURL;
+@property (nonatomic, readonly) NSString *vastTag; // Optional vast ad tag for video.
+@property (nonatomic, readonly) IDMVASTAdPlayType adPlayType;
 @property (nonatomic, strong) IDMProgressUpdateBlock progressUpdateBlock;
 @property (nonatomic, strong) UIImage *placeholderImage;
 @property (nonatomic, strong) UIImage *failureIcon;
@@ -40,8 +49,7 @@ typedef void (^IDMProgressUpdateBlock)(CGFloat progress);
 + (NSArray *)photosWithURLs:(NSArray *)urlsArray;
 
 + (IDMPhoto *)videoWithURL:(NSURL *)url;
-
-+ (NSArray *)videosWithURLs:(NSArray *)urlsArray;
++ (IDMPhoto *)videoWithURL:(NSURL *)url vastTag:(NSString *)vastTag adPlayType:(IDMVASTAdPlayType)adPlayType;
 
 // Init
 - (id)initWithImage:(UIImage *)image;

--- a/Classes/IDMPhoto.m
+++ b/Classes/IDMPhoto.m
@@ -38,6 +38,8 @@
 @synthesize underlyingImage = _underlyingImage, 
 photoURL = _photoURL,
 videoURL = _videoURL,
+vastTag = _vastTag,
+adPlayType = _adPlayType,
 caption = _caption,
 type = _type;
 
@@ -99,24 +101,11 @@ type = _type;
 }
 
 + (IDMPhoto *)videoWithURL:(NSURL *)url {
-    return [[IDMPhoto alloc] initWithVideoURL:url];
+    return [IDMPhoto videoWithURL:url vastTag:nil adPlayType:kIDMVASTAdPlayTypeDefault];
 }
 
-+ (NSArray *)videosWithURLs:(NSArray *)urlsArray {
-    NSMutableArray *videos = [NSMutableArray arrayWithCapacity:urlsArray.count];
-
-    for (id url in urlsArray) {
-        if ([url isKindOfClass:[NSURL class]]) {
-            IDMPhoto *video = [IDMPhoto videoWithURL:[NSURL URLWithString:url]];
-            [videos addObject:video];
-        }
-        else if ([url isKindOfClass:[NSString class]]) {
-            IDMPhoto *video = [IDMPhoto videoWithURL:[NSURL URLWithString:url]];
-            [videos addObject:video];
-        }
-    }
-
-    return videos;
++ (IDMPhoto *)videoWithURL:(NSURL *)url vastTag:(NSString *)vastTag adPlayType:(IDMVASTAdPlayType)adPlayType {
+    return [[IDMPhoto alloc] initWithVideoURL:url vastTag:vastTag adPlayType:adPlayType];
 }
 
 #pragma mark NSObject
@@ -149,6 +138,16 @@ type = _type;
     if ((self = [super init])) {
         _videoURL = videoURL;
         _type = kMediaTypeVideo;
+    }
+    return self;
+}
+
+- (id)initWithVideoURL:(NSURL *)videoURL vastTag:(NSString *)vastTag adPlayType:(IDMVASTAdPlayType)adPlayType {
+    if ((self = [super init])) {
+        _videoURL = videoURL;
+        _type = kMediaTypeVideo;
+        _vastTag = vastTag;
+        _adPlayType = adPlayType;
     }
     return self;
 }

--- a/Demo/PhotoBrowserDemo.xcodeproj/project.pbxproj
+++ b/Demo/PhotoBrowserDemo.xcodeproj/project.pbxproj
@@ -326,6 +326,7 @@
 				4C6F978914AF734800F8389A /* Sources */,
 				4C6F978A14AF734800F8389A /* Frameworks */,
 				4C6F978B14AF734800F8389A /* Resources */,
+				EB6DA076CE324BC68C4E5C18 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -454,6 +455,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		EB6DA076CE324BC68C4E5C18 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PhotoBrowserDemo/Pods-PhotoBrowserDemo-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/GoogleAds-IMA-iOS-SDK/GoogleInteractiveMediaAds.framework/GoogleInteractiveMediaAds",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleInteractiveMediaAds.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PhotoBrowserDemo/Pods-PhotoBrowserDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -538,7 +557,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0.1;
@@ -583,7 +602,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -605,7 +624,7 @@
 				GCC_PREFIX_HEADER = "PhotoBrowserDemo/PhotoBrowserDemo-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				INFOPLIST_FILE = "PhotoBrowserDemo/PhotoBrowserDemo-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.appkraft.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -630,7 +649,7 @@
 				GCC_PREFIX_HEADER = "PhotoBrowserDemo/PhotoBrowserDemo-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				INFOPLIST_FILE = "PhotoBrowserDemo/PhotoBrowserDemo-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.appkraft.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -671,7 +690,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = PhotoBrowserDemoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.appkraft.PhotoBrowserDemoTests;
@@ -712,7 +731,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = PhotoBrowserDemoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.appkraft.PhotoBrowserDemoTests;

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -3,8 +3,9 @@ inhibit_all_warnings!
 
 target "PhotoBrowserDemo" do
 
-pod 'SDWebImage', '~> 5.11.1'
+pod 'SDWebImage', '5.18.2'
 pod 'DACircularProgress'
 pod 'pop'
+pod 'GoogleAds-IMA-iOS-SDK', '3.20.0'
 
 end

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,26 +1,30 @@
 PODS:
   - DACircularProgress (2.3.1)
+  - GoogleAds-IMA-iOS-SDK (3.20.0)
   - pop (1.0.9)
-  - SDWebImage (5.11.1):
-    - SDWebImage/Core (= 5.11.1)
-  - SDWebImage/Core (5.11.1)
+  - SDWebImage (5.18.2):
+    - SDWebImage/Core (= 5.18.2)
+  - SDWebImage/Core (5.18.2)
 
 DEPENDENCIES:
   - DACircularProgress
+  - GoogleAds-IMA-iOS-SDK (= 3.20.0)
   - pop
-  - SDWebImage (~> 5.11.1)
+  - SDWebImage (= 5.18.2)
 
 SPEC REPOS:
   trunk:
     - DACircularProgress
+    - GoogleAds-IMA-iOS-SDK
     - pop
     - SDWebImage
 
 SPEC CHECKSUMS:
   DACircularProgress: 4dd437c0fc3da5161cb289e07ac449493d41db71
+  GoogleAds-IMA-iOS-SDK: f9a6bd69e34f6c3a2d6b2f7cd56814b78fc680f9
   pop: f667631a5108a2e60d9e8797c9b32ddaf2080bce
-  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
+  SDWebImage: c0de394d7cf7f9838aed1fd6bb6037654a4572e4
 
-PODFILE CHECKSUM: e339e8bf591f3ee05a27bc10c152222275ae8330
+PODFILE CHECKSUM: d067d7db4d8624253c3cee7cedfbc7d4a8c16632
 
-COCOAPODS: 1.11.1
+COCOAPODS: 1.13.0

--- a/IDMPhotoBrowser.podspec
+++ b/IDMPhotoBrowser.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.dependency       'SDWebImage'
   s.dependency       'DACircularProgress'
   s.dependency       'pop'
+  s.dependency       'GoogleAds-IMA-iOS-SDK'
   end


### PR DESCRIPTION
1. Upgrade Deployment Target from 10 to 14 as preparation for integrating GoogleAds-IMA-iOS-SDK.
2. Integrate GoogleAds-IMA-iOS-SDK via CocoaPods.
3. API modification to accept vast tag as parameter for video content.